### PR TITLE
Fixed deprecated async_get_registry()

### DIFF
--- a/custom_components/sagemcom_fast/__init__.py
+++ b/custom_components/sagemcom_fast/__init__.py
@@ -124,7 +124,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     }
 
     # Create gateway device in Home Assistant
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = hass.helpers.device_registry.async_get(hass)
 
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,


### PR DESCRIPTION
Fixed error with deprecated attribute/method async_get_registry()

Fix of issue #50 

Fix applied based on documentation seen here:
[Home Assistant Dev Documentation](https://dev-docs.home-assistant.io/en/dev/api/helpers.html) .

<details><summary>Quoted Details</summary>
<p>

homeassistant.helpers.area_registry.async_get(hass: homeassistant.core.HomeAssistant) → homeassistant.helpers.area_registry.AreaRegistry[[source]](https://github.com/home-assistant/home-assistant/blob/dev//homeassistant/helpers/area_registry.py#L211)[¶](https://dev-docs.home-assistant.io/en/dev/api/helpers.html#homeassistant.helpers.area_registry.async_get)
Get area registry.

async homeassistant.helpers.area_registry.async_get_registry(hass: homeassistant.core.HomeAssistant) → homeassistant.helpers.area_registry.AreaRegistry[[source]](https://github.com/home-assistant/home-assistant/blob/dev//homeassistant/helpers/area_registry.py#L224)
Get area registry.

This is deprecated and will be removed in the future. Use async_get instead.

</p>
</details> 
