### PR TITLE
Fix InvalidSessionException treated as permanent auth failure

### DIFF
--- a/custom_components/sagemcom_fast/coordinator.py
+++ b/custom_components/sagemcom_fast/coordinator.py
@@ -15,6 +15,7 @@ from sagemcom_api.client import SagemcomClient
 from sagemcom_api.exceptions import (
     AccessRestrictionException,
     AuthenticationException,
+    InvalidSessionException,
     LoginRetryErrorException,
     MaximumSessionCountException,
     UnauthorizedException,
@@ -67,6 +68,10 @@ class SagemcomDataUpdateCoordinator(DataUpdateCoordinator):
                 return self.hosts
         except AccessRestrictionException as exception:
             raise ConfigEntryAuthFailed("Access restricted") from exception
+        except InvalidSessionException as exception:
+            raise UpdateFailed(
+                "Session invalidated by router. Retrying later."
+            ) from exception
         except (AuthenticationException, UnauthorizedException) as exception:
             raise ConfigEntryAuthFailed("Invalid credentials") from exception
         except (TimeoutError, ClientError, ConnectionError) as exception:


### PR DESCRIPTION
## Summary

`InvalidSessionException` inherits from `UnauthorizedException`, so it was being caught by the `(AuthenticationException, UnauthorizedException)` handler which raises `ConfigEntryAuthFailed`. This permanently disables the integration and marks all entities as `unavailable`, requiring user re-authentication.

## Problem

When the router invalidates a session (e.g., due to a concurren login to the web interface using the same client IP as the Home Assistant server), the integration receives `XMO_INVALID_SESSION_ERR`. This is a transient condition, not a credentials problem. However, due to the exception hierarchy (`InvalidSessionException` → `UnauthorizedException`), it was treated as a permanent auth failure.

## Fix

Catch `InvalidSessionException` explicitly before the `UnauthorizedException` handler and raise `UpdateFailed` instead of `ConfigEntryAuthFailed`. This allows the coordinator to retry on the next polling cycle and recover automatically.

## Testing

Reproduced the issue by logging into the router web interface during a poll cycle. Before the fix, the integration died permanently. After the fix, it logs a warning and recovers on the next poll.